### PR TITLE
add ability to send slack notification

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@3.4.2
+
 description: >
   Deploy a helm chart to Kubernetes.
   Built for internal use at Penn Labs.

--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -37,4 +37,3 @@ steps:
       helm repo add pennlabs https://helm.pennlabs.org/
 
       helm upgrade --install --atomic --set=image_tag=$IMAGE_TAG -f k8s/values.yaml --version "${DEPLOY_TAG}" $RELEASE_NAME pennlabs/icarus
-

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -13,3 +13,12 @@ steps:
   - checkout
   - deploy:
       deploy-tag: "<<parameters.deploy-tag>>"
+  - when:
+      condition: <<parameters.send-slack-alert>>
+      steps:
+        - slack/status:
+          context: slack
+          success_message: "Deployment success!"
+          failure_message: "Deployment failure."
+          include_project_field: true
+          include_visit_job_action: true

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -17,8 +17,8 @@ steps:
       condition: <<parameters.send-slack-alert>>
       steps:
         - slack/status:
-          context: slack
-          success_message: "Deployment success!"
-          failure_message: "Deployment failure."
-          include_project_field: true
-          include_visit_job_action: true
+            context: slack
+            success_message: "Deployment success!"
+            failure_message: "Deployment failure."
+            include_project_field: true
+            include_visit_job_action: true

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -24,5 +24,3 @@ steps:
         - slack/status: # Make sure SLACK_WEBHOOK is defined in the k8s-deploy context.
             success_message: ":tada: SUCCESS :tada:"
             failure_message: ":octagonal_sign: FAILURE :octagonal_sign:"
-            include_project_field: true
-            include_visit_job_action: true

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -21,9 +21,8 @@ steps:
   - when:
       condition: <<parameters.send-slack-alert>>
       steps:
-        - slack/status:
-            context: slack
-            success_message: "Deployment success!"
-            failure_message: "Deployment failure."
+        - slack/status: # Make sure SLACK_WEBHOOK is defined in the k8s-deploy context.
+            success_message: ":tada: SUCCESS :tada:"
+            failure_message: ":octagonal_sign: FAILURE :octagonal_sign:"
             include_project_field: true
             include_visit_job_action: true

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -8,6 +8,11 @@ parameters:
     type: string
     default: "${CIRCLE_SHA1}"
     description: Image tag to use for deployments. Defaults to ${CIRCLE_SHA1}
+  send-slack-alert:
+    type: boolean
+    default: true
+    description: >
+      Whether or not to send slack alerts to the deployment channel
 
 steps:
   - checkout


### PR DESCRIPTION
This PR adds the ability to send slack notifications on a successful/unsuccessful deployment. Uses the webhook defined in the `SLACK_WEBHOOK` environment variable, which for us is defined in the `slack` context that I added to CircleCI.

Set up a #deployments channel on slack for this 😄 